### PR TITLE
update nestjs installation guide

### DIFF
--- a/installation/plugins/nest.md
+++ b/installation/plugins/nest.md
@@ -20,7 +20,7 @@ As of version `5.x.x` of `@adminjs/nestjs`, the plugin only supports Nest server
 If you are starting a new project, install `nest-cli` and bootstrap the project:
 
 ```bash
-$ npm i -g nest-cli
+$ npm i -g @nestjs/cli
 $ nest new
 ```
 {% endhint %}


### PR DESCRIPTION
according to https://docs.nestjs.com/cli/overview. The new installation package for nest is ```npm install -g @nestjs/cli``` instead of ```npm install -g nest-cli```