### PR TITLE
Add componentLoader in dashboard customization

### DIFF
--- a/ui-customization/dashboard-customization.md
+++ b/ui-customization/dashboard-customization.md
@@ -46,6 +46,7 @@ const admin = new AdminJS({
   dashboard: {
     component: Components.Dashboard,
   },
+  componentLoader
 })
 ```
 
@@ -71,6 +72,7 @@ const admin = new AdminJS({
     component: Components.Dashboard,
     handler: dashboardHandler,
   },
+  componentLoader
 })
 ```
 


### PR DESCRIPTION
There's missing property in the adminJs initialization - 'componentLoader' that is required for the customized dashboard to take place